### PR TITLE
Add Benchmarks

### DIFF
--- a/tracer/bench_test.go
+++ b/tracer/bench_test.go
@@ -1,0 +1,42 @@
+package tracer
+
+// benchResults holds all benchmark results to prevent compiler optimizations
+type benchResults struct {
+	// Matrix results
+	matrix struct {
+		mat2 Mat[Size2]
+		mat3 Mat[Size3]
+		mat4 Mat[Size4]
+	}
+	// Canvas results
+	canvas struct {
+		c   Canvas
+		str string
+	}
+	// Color results
+	color struct {
+		c     HDRColor
+		float float64
+	}
+	// Ray results
+	ray struct {
+		r    Ray
+		ints []Intersect
+	}
+	// Transform results
+	transform struct {
+		mat4 Mat[Size4]
+	}
+	// Tuple results
+	tuple struct {
+		t     Tuple
+		float float64
+	}
+	// Shared scalar results
+	scalar struct {
+		float float64
+		bool  bool
+	}
+}
+
+var results benchResults

--- a/tracer/canvas_bench_test.go
+++ b/tracer/canvas_bench_test.go
@@ -1,0 +1,82 @@
+package tracer
+
+import (
+	"image/color"
+	"testing"
+)
+
+func BenchmarkCanvasCreation(b *testing.B) {
+	b.Run("NewCanvas/Small", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.canvas.c = NewCanvas(100, 100)
+		}
+	})
+
+	b.Run("NewCanvas/Medium", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.canvas.c = NewCanvas(500, 500)
+		}
+	})
+
+	b.Run("NewCanvas/Large", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.canvas.c = NewCanvas(1000, 1000)
+		}
+	})
+}
+
+func BenchmarkCanvasOperations(b *testing.B) {
+	canvas := NewCanvas(100, 100)
+	clr := HDRColor{0x8000, 0x4000, 0x2000}
+	rgbaClr := color.RGBA{128, 64, 32, 255}
+
+	b.Run("At/InBounds", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.color.c = canvas.AtHDR(50, 50)
+		}
+	})
+
+	b.Run("At/OutOfBounds", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.color.c = canvas.AtHDR(150, 150)
+		}
+	})
+
+	b.Run("Set/HDRColor", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			canvas.SetColor(50, 50, clr)
+		}
+	})
+
+	b.Run("Set/RGBAColor", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			canvas.Set(50, 50, rgbaClr)
+		}
+	})
+}
+
+func BenchmarkCanvasExport(b *testing.B) {
+	canvas := NewCanvas(100, 100)
+	// Fill canvas with some test data
+	for x := 0; x < 100; x++ {
+		for y := 0; y < 100; y++ {
+			canvas.SetColor(x, y, HDRColor{
+				R: uint64(x * 256),
+				G: uint64(y * 256),
+				B: uint64((x + y) * 128),
+			})
+		}
+	}
+
+	b.Run("PPMString/255", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.canvas.str = canvas.PPMStr(255)
+		}
+	})
+
+	b.Run("PPMString/65535", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.canvas.str = canvas.PPMStr(65535)
+		}
+	})
+}

--- a/tracer/color_bench_test.go
+++ b/tracer/color_bench_test.go
@@ -1,0 +1,97 @@
+package tracer
+
+import (
+	"testing"
+)
+
+func BenchmarkColorCreation(b *testing.B) {
+	b.Run("NewColorFromFloat64", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.color.c = NewColorFromFloat64(0.8, 0.1, 0.3)
+		}
+	})
+}
+
+func BenchmarkColorOperations(b *testing.B) {
+	c1 := HDRColor{0x8000, 0x4000, 0x2000}
+	c2 := HDRColor{0x2000, 0x4000, 0x8000}
+	f := uint64(2)
+
+	b.Run("Plus", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.color.c = c1.Plus(c2)
+		}
+	})
+
+	b.Run("Minus", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.color.c = c1.Minus(c2)
+		}
+	})
+
+	b.Run("Times", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.color.c = c1.Times(f)
+		}
+	})
+
+	b.Run("Hadamard", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.color.c = c1.Hadamard(c2)
+		}
+	})
+}
+
+func BenchmarkColorConversions(b *testing.B) {
+	c := HDRColor{0x8000, 0x4000, 0x2000}
+
+	b.Run("RGBA", func(be *testing.B) {
+		var r, g, b uint32
+		for i := 0; i < be.N; i++ {
+			r, g, b, _ = c.RGBA()
+			// Store in results to prevent optimization
+			results.color.c = HDRColor{uint64(r), uint64(g), uint64(b)}
+		}
+	})
+
+	b.Run("ToPPMRange", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.color.c = c.ToPPMRange(255)
+		}
+	})
+
+	b.Run("AsFloats", func(be *testing.B) {
+		var r, g, b float64
+		for i := 0; i < be.N; i++ {
+			r, g, b = c.AsFloats()
+			results.scalar.float = r + g + b // Store to prevent optimization
+		}
+	})
+
+	b.Run("AsInts", func(be *testing.B) {
+		var r, g, b int
+		for i := 0; i < be.N; i++ {
+			r, g, b = c.AsInts()
+			results.scalar.float = float64(r + g + b) // Store to prevent optimization
+		}
+	})
+}
+
+func BenchmarkColorComparisons(b *testing.B) {
+	c1 := HDRColor{0x8000, 0x4000, 0x2000}
+	c2 := HDRColor{0x2000, 0x4000, 0x8000}
+
+	b.Run("Equals", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.scalar.bool = c1.Equals(c2)
+		}
+	})
+
+	b.Run("Distance", func(b *testing.B) {
+		var d uint64
+		for i := 0; i < b.N; i++ {
+			d = c1.Distance(c2)
+			results.color.c.R = d // Store to prevent optimization
+		}
+	})
+}

--- a/tracer/matrix_bench_test.go
+++ b/tracer/matrix_bench_test.go
@@ -10,7 +10,7 @@ var (
 	resultMat3  Mat[Size3]
 	resultMat4  Mat[Size4]
 	resultFloat float64
-	resultBool2 bool
+	resultBool2 bool // TODO: Name this better!
 	resultTuple Tuple
 )
 

--- a/tracer/matrix_bench_test.go
+++ b/tracer/matrix_bench_test.go
@@ -4,15 +4,41 @@ import (
 	"testing"
 )
 
-// Prevent compiler optimizations
-var (
-	resultMat2  Mat[Size2]
-	resultMat3  Mat[Size3]
-	resultMat4  Mat[Size4]
-	resultFloat float64
-	resultBool2 bool // TODO: Name this better!
-	resultTuple Tuple
-)
+// benchResults holds all benchmark results to prevent compiler optimizations
+type benchResults struct {
+	// Matrix results
+	matrix struct {
+		mat2 Mat[Size2]
+		mat3 Mat[Size3]
+		mat4 Mat[Size4]
+	}
+	// Color results
+	color struct {
+		c     HDRColor
+		float float64
+	}
+	// Ray results
+	ray struct {
+		r    Ray
+		ints []Intersect
+	}
+	// Transform results
+	transform struct {
+		mat4 Mat[Size4]
+	}
+	// Tuple results
+	tuple struct {
+		t     Tuple
+		float float64
+	}
+	// Shared scalar results
+	scalar struct {
+		float float64
+		bool  bool
+	}
+}
+
+var results benchResults
 
 func BenchmarkMatrixCreation(b *testing.B) {
 	vals2 := []float64{1, 2, 3, 4}
@@ -21,19 +47,19 @@ func BenchmarkMatrixCreation(b *testing.B) {
 
 	b.Run("NewMat2", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat2 = NewMat[Size2](vals2)
+			results.matrix.mat2 = NewMat[Size2](vals2)
 		}
 	})
 
 	b.Run("NewMat3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat3 = NewMat[Size3](vals3)
+			results.matrix.mat3 = NewMat[Size3](vals3)
 		}
 	})
 
 	b.Run("NewMat4", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat4 = NewMat[Size4](vals4)
+			results.matrix.mat4 = NewMat[Size4](vals4)
 		}
 	})
 }
@@ -46,37 +72,37 @@ func BenchmarkMatrixOperations(b *testing.B) {
 
 	b.Run("Times/2x2", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat2 = m2.Times(m2)
+			results.matrix.mat2 = m2.Times(m2)
 		}
 	})
 
 	b.Run("Times/3x3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat3 = m3.Times(m3)
+			results.matrix.mat3 = m3.Times(m3)
 		}
 	})
 
 	b.Run("Times/4x4", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat4 = m4.Times(m4)
+			results.matrix.mat4 = m4.Times(m4)
 		}
 	})
 
 	b.Run("TimesTuple", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultTuple = m4.TimesTuple(t)
+			results.tuple.t = m4.TimesTuple(t)
 		}
 	})
 
 	b.Run("Transpose/2x2", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat2 = m2.Transpose()
+			results.matrix.mat2 = m2.Transpose()
 		}
 	})
 
 	b.Run("Transpose/4x4", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat4 = m4.Transpose()
+			results.matrix.mat4 = m4.Transpose()
 		}
 	})
 }
@@ -88,19 +114,19 @@ func BenchmarkMatrixDeterminants(b *testing.B) {
 
 	b.Run("Determinant/2x2", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultFloat = m2.Determinant()
+			results.scalar.float = m2.Determinant()
 		}
 	})
 
 	b.Run("Determinant/3x3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultFloat = m3.Determinant()
+			results.scalar.float = m3.Determinant()
 		}
 	})
 
 	b.Run("Determinant/4x4", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultFloat = m4.Determinant()
+			results.scalar.float = m4.Determinant()
 		}
 	})
 }
@@ -118,25 +144,25 @@ func BenchmarkMatrixInverse(b *testing.B) {
 
 	b.Run("CanInverse/2x2", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultBool2 = m2.CanInverse()
+			results.scalar.bool = m2.CanInverse()
 		}
 	})
 
 	b.Run("Inverse/2x2", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat2 = m2.Inverse()
+			results.matrix.mat2 = m2.Inverse()
 		}
 	})
 
 	b.Run("Inverse/3x3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat3 = m3.Inverse()
+			results.matrix.mat3 = m3.Inverse()
 		}
 	})
 
 	b.Run("Inverse/4x4", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat4 = m4.Inverse()
+			results.matrix.mat4 = m4.Inverse()
 		}
 	})
 }
@@ -147,25 +173,25 @@ func BenchmarkMatrixSubOperations(b *testing.B) {
 
 	b.Run("SubMat/3x3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat2 = SubMat[Size3, Size2](m3, 0, 0)
+			results.matrix.mat2 = SubMat[Size3, Size2](m3, 0, 0)
 		}
 	})
 
 	b.Run("SubMat/4x4", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultMat3 = SubMat[Size4, Size3](m4, 0, 0)
+			results.matrix.mat3 = SubMat[Size4, Size3](m4, 0, 0)
 		}
 	})
 
 	b.Run("Minor/3x3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultFloat = Minor(m3, 0, 0)
+			results.scalar.float = Minor(m3, 0, 0)
 		}
 	})
 
 	b.Run("Cofactor/3x3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			resultFloat = Cofactor(m3, 0, 0)
+			results.scalar.float = Cofactor(m3, 0, 0)
 		}
 	})
 }

--- a/tracer/matrix_bench_test.go
+++ b/tracer/matrix_bench_test.go
@@ -1,0 +1,171 @@
+package tracer
+
+import (
+	"testing"
+)
+
+// Prevent compiler optimizations
+var (
+	resultMat2  Mat[Size2]
+	resultMat3  Mat[Size3]
+	resultMat4  Mat[Size4]
+	resultFloat float64
+	resultBool2 bool
+	resultTuple Tuple
+)
+
+func BenchmarkMatrixCreation(b *testing.B) {
+	vals2 := []float64{1, 2, 3, 4}
+	vals3 := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}
+	vals4 := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16}
+
+	b.Run("NewMat2", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat2 = NewMat[Size2](vals2)
+		}
+	})
+
+	b.Run("NewMat3", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat3 = NewMat[Size3](vals3)
+		}
+	})
+
+	b.Run("NewMat4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat4 = NewMat[Size4](vals4)
+		}
+	})
+}
+
+func BenchmarkMatrixOperations(b *testing.B) {
+	m2 := NewMat[Size2]([]float64{1, 2, 3, 4})
+	m3 := NewMat[Size3]([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	m4 := NewMat[Size4]([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+	t := NewPoint(1, 2, 3)
+
+	b.Run("Times/2x2", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat2 = m2.Times(m2)
+		}
+	})
+
+	b.Run("Times/3x3", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat3 = m3.Times(m3)
+		}
+	})
+
+	b.Run("Times/4x4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat4 = m4.Times(m4)
+		}
+	})
+
+	b.Run("TimesTuple", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultTuple = m4.TimesTuple(t)
+		}
+	})
+
+	b.Run("Transpose/2x2", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat2 = m2.Transpose()
+		}
+	})
+
+	b.Run("Transpose/4x4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat4 = m4.Transpose()
+		}
+	})
+}
+
+func BenchmarkMatrixDeterminants(b *testing.B) {
+	m2 := NewMat[Size2]([]float64{1, 2, 3, 4})
+	m3 := NewMat[Size3]([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	m4 := NewMat[Size4]([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	b.Run("Determinant/2x2", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultFloat = m2.Determinant()
+		}
+	})
+
+	b.Run("Determinant/3x3", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultFloat = m3.Determinant()
+		}
+	})
+
+	b.Run("Determinant/4x4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultFloat = m4.Determinant()
+		}
+	})
+}
+
+func BenchmarkMatrixInverse(b *testing.B) {
+	// Use matrices that we know are invertible
+	m2 := NewMat[Size2]([]float64{4, 7, 2, 6})
+	m3 := NewMat[Size3]([]float64{1, 2, 3, 0, 1, 4, 5, 6, 0})
+	m4 := NewMat[Size4]([]float64{
+		8, -5, 9, 2,
+		7, 5, 6, 1,
+		-6, 0, 9, 6,
+		-3, 0, -9, -4,
+	})
+
+	b.Run("CanInverse/2x2", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultBool2 = m2.CanInverse()
+		}
+	})
+
+	b.Run("Inverse/2x2", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat2 = m2.Inverse()
+		}
+	})
+
+	b.Run("Inverse/3x3", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat3 = m3.Inverse()
+		}
+	})
+
+	b.Run("Inverse/4x4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat4 = m4.Inverse()
+		}
+	})
+}
+
+func BenchmarkMatrixSubOperations(b *testing.B) {
+	m3 := NewMat[Size3]([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9})
+	m4 := NewMat[Size4]([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16})
+
+	b.Run("SubMat/3x3", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat2 = SubMat[Size3, Size2](m3, 0, 0)
+		}
+	})
+
+	b.Run("SubMat/4x4", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat3 = SubMat[Size4, Size3](m4, 0, 0)
+		}
+	})
+
+	b.Run("Minor/3x3", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultFloat = Minor(m3, 0, 0)
+		}
+	})
+
+	b.Run("Cofactor/3x3", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultFloat = Cofactor(m3, 0, 0)
+		}
+	})
+}

--- a/tracer/matrix_bench_test.go
+++ b/tracer/matrix_bench_test.go
@@ -4,42 +4,6 @@ import (
 	"testing"
 )
 
-// benchResults holds all benchmark results to prevent compiler optimizations
-type benchResults struct {
-	// Matrix results
-	matrix struct {
-		mat2 Mat[Size2]
-		mat3 Mat[Size3]
-		mat4 Mat[Size4]
-	}
-	// Color results
-	color struct {
-		c     HDRColor
-		float float64
-	}
-	// Ray results
-	ray struct {
-		r    Ray
-		ints []Intersect
-	}
-	// Transform results
-	transform struct {
-		mat4 Mat[Size4]
-	}
-	// Tuple results
-	tuple struct {
-		t     Tuple
-		float float64
-	}
-	// Shared scalar results
-	scalar struct {
-		float float64
-		bool  bool
-	}
-}
-
-var results benchResults
-
 func BenchmarkMatrixCreation(b *testing.B) {
 	vals2 := []float64{1, 2, 3, 4}
 	vals3 := []float64{1, 2, 3, 4, 5, 6, 7, 8, 9}

--- a/tracer/matrix_bench_test.go
+++ b/tracer/matrix_bench_test.go
@@ -148,11 +148,12 @@ func BenchmarkMatrixInverse(b *testing.B) {
 		}
 	})
 
-	b.Run("Inverse/2x2", func(b *testing.B) {
-		for i := 0; i < b.N; i++ {
-			results.matrix.mat2 = m2.Inverse()
-		}
-	})
+	// BUG: Minor only supported for Mat3 and Mat4
+	// b.Run("Inverse/2x2", func(b *testing.B) {
+	// 	for i := 0; i < b.N; i++ {
+	// 		results.matrix.mat2 = m2.Inverse()
+	// 	}
+	// })
 
 	b.Run("Inverse/3x3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {

--- a/tracer/ray_bench_test.go
+++ b/tracer/ray_bench_test.go
@@ -1,0 +1,116 @@
+package tracer
+
+import (
+	"testing"
+)
+
+// Prevent compiler optimizations
+var (
+	resultRay  Ray
+	resultInts []Intersect
+	resultInt  Intersect
+	resultBool bool
+	resultSph  Sphere
+)
+
+func BenchmarkRayCreation(b *testing.B) {
+	origin := NewPoint(1, 2, 3)
+	direction := NewVector(4, 5, 6)
+
+	b.Run("NewRay", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultRay = NewRay(origin, direction)
+		}
+	})
+
+	b.Run("NewSphere", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultSph = NewSphere()
+		}
+	})
+}
+
+func BenchmarkRayOperations(b *testing.B) {
+	ray := NewRay(NewPoint(0, 0, -5), NewVector(0, 0, 1))
+	m := I4.Scale(2, 2, 2)
+
+	b.Run("Position", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = ray.Position(2.0)
+		}
+	})
+
+	b.Run("Transform", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultRay = ray.Transform(m)
+		}
+	})
+}
+
+func BenchmarkIntersections(b *testing.B) {
+	ray := NewRay(NewPoint(0, 0, -5), NewVector(0, 0, 1))
+	sphere := NewSphere()
+	xs := []Intersect{
+		NewIntersect(sphere, 1),
+		NewIntersect(sphere, 2),
+		NewIntersect(sphere, -1),
+	}
+
+	b.Run("GetIntersects", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultInts = sphere.GetIntersects(ray)
+		}
+	})
+
+	b.Run("Hit/Sorted", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultInt, resultBool = Hit(xs)
+		}
+	})
+
+	b.Run("Hit/Unsorted", func(b *testing.B) {
+		unsorted := []Intersect{
+			NewIntersect(sphere, 2),
+			NewIntersect(sphere, -1),
+			NewIntersect(sphere, 1),
+		}
+		for i := 0; i < b.N; i++ {
+			resultInt, resultBool = Hit(unsorted)
+		}
+	})
+}
+
+func BenchmarkIntersectComparisons(b *testing.B) {
+	sphere := NewSphere()
+	x1 := NewIntersect(sphere, 1)
+	x2 := NewIntersect(sphere, 1)
+
+	b.Run("Equals", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultBool = x1.Equals(x2)
+		}
+	})
+
+	b.Run("Same", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultBool = x1.Same(x2)
+		}
+	})
+}
+
+func BenchmarkIntersectCreation(b *testing.B) {
+	sphere := NewSphere()
+	times := []float64{1, 2, 3, 4, 5}
+
+	b.Run("NewIntersect", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultInt = NewIntersect(sphere, 1.0)
+		}
+	})
+
+	b.Run("NewIntersects", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultInts = NewIntersects(sphere, times...)
+		}
+	})
+}

--- a/tracer/transform_bench_test.go
+++ b/tracer/transform_bench_test.go
@@ -1,0 +1,82 @@
+package tracer
+
+import (
+	"math"
+	"testing"
+)
+
+// Prevent compiler optimizations
+var resultMat Mat[Size4]
+
+func BenchmarkTransformations(b *testing.B) {
+	// Setup test matrix
+	m := I4
+
+	b.Run("Translate", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat = m.Translate(2, 3, 4)
+		}
+	})
+
+	b.Run("Scale", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat = m.Scale(2, 3, 4)
+		}
+	})
+
+	b.Run("RotateX", func(b *testing.B) {
+		rad := math.Pi / 4
+		for i := 0; i < b.N; i++ {
+			resultMat = m.RotateX(rad)
+		}
+	})
+
+	b.Run("RotateY", func(b *testing.B) {
+		rad := math.Pi / 4
+		for i := 0; i < b.N; i++ {
+			resultMat = m.RotateY(rad)
+		}
+	})
+
+	b.Run("RotateZ", func(b *testing.B) {
+		rad := math.Pi / 4
+		for i := 0; i < b.N; i++ {
+			resultMat = m.RotateZ(rad)
+		}
+	})
+
+	b.Run("Shear", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat = m.Shear(1, 2, 3, 4, 5, 6)
+		}
+	})
+}
+
+func BenchmarkTransformationChains(b *testing.B) {
+	m := I4
+	rad := math.Pi / 4
+
+	b.Run("RotateScale", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat = m.RotateZ(rad).Scale(2, 3, 4)
+		}
+	})
+
+	b.Run("TranslateRotateScale", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat = m.Translate(5, 6, 7).RotateZ(rad).Scale(2, 3, 4)
+		}
+	})
+
+	b.Run("ComplexChain", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			resultMat = m.
+				Translate(1, 2, 3).
+				RotateX(rad).
+				RotateY(rad).
+				RotateZ(rad).
+				Scale(2, 2, 2).
+				Shear(1, 0, 0, 0, 0, 1)
+		}
+	})
+}

--- a/tracer/tuple_bench_test.go
+++ b/tracer/tuple_bench_test.go
@@ -1,0 +1,81 @@
+package tracer
+
+import (
+	"testing"
+)
+
+// Prevent compiler optimizations
+var result Tuple
+
+func BenchmarkTupleCreation(b *testing.B) {
+	b.Run("NewPoint", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			result = NewPoint(1.0, 2.0, 3.0)
+		}
+	})
+
+	b.Run("NewVector", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			result = NewVector(1.0, 2.0, 3.0)
+		}
+	})
+}
+
+func BenchmarkTupleOperations(b *testing.B) {
+	p1 := NewPoint(1.0, 2.0, 3.0)
+	p2 := NewPoint(4.0, 5.0, 6.0)
+	v1 := NewVector(1.0, 2.0, 3.0)
+
+	b.Run("Plus", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			result = p1.Plus(v1)
+		}
+	})
+
+	b.Run("Minus", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			result = p1.Minus(p2)
+		}
+	})
+
+	b.Run("Times", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			result = v1.Times(2.5)
+		}
+	})
+}
+
+func BenchmarkTupleVectorMath(b *testing.B) {
+	v1 := NewVector(1.0, 2.0, 3.0)
+	v2 := NewVector(4.0, 5.0, 6.0)
+
+	b.Run("Length", func(b *testing.B) {
+		var l float64
+		for i := 0; i < b.N; i++ {
+			l = v1.Length()
+		}
+		// Prevent optimization
+		result = NewVector(l, 0, 0)
+	})
+
+	b.Run("Normalized", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			result = v1.Normalized()
+		}
+	})
+
+	b.Run("Dot", func(b *testing.B) {
+		var d float64
+		for i := 0; i < b.N; i++ {
+			d = v1.Dot(v2)
+		}
+		// Prevent optimization
+		result = NewVector(d, 0, 0)
+	})
+
+	b.Run("Cross", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			result = v1.Cross(v2)
+		}
+	})
+}

--- a/tracer/tuple_bench_test.go
+++ b/tracer/tuple_bench_test.go
@@ -43,6 +43,12 @@ func BenchmarkTupleOperations(b *testing.B) {
 			result = v1.Times(2.5)
 		}
 	})
+
+	b.Run("Divide", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			result = v1.Divide(2.5)
+		}
+	})
 }
 
 func BenchmarkTupleVectorMath(b *testing.B) {


### PR DESCRIPTION
**Phase 1: Initial Framework (Jan 19)**

* Added basic tuple benchmarks
* Added transform benchmarks
* Set up baseline benchmark utilities

**Phase 2: Core Implementation (Jan 24)**

* Added centralized benchResults struct
* Created focused benchmark suites:
    * Matrix operations (creation, multiplication, determinants)
    * Color operations (creation, math, HDR handling)
    * Canvas operations (creation, pixel ops, exports)
    * Ray operations (intersections, transformations)


* Disabled 2x2 submatrix ops until implemented
* Added compiler optimization prevention