### PR TITLE
Convert HDRColor from int64 to float32. Rename HDRColor to LinearColor. Make Inverse() not panicky.

### DIFF
--- a/.github/workflows/go-ci.yml
+++ b/.github/workflows/go-ci.yml
@@ -17,14 +17,14 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.21'
+        go-version: '1.21.x'
 
     - name: Install dependencies
       run: go mod download
 
-    - name: Run Tests
-      run: make test
-      timeout-minutes: 1
+    - name: Run Checks
+      run: make check
+      timeout-minutes: 3
 
     - name: Build Application
       run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,8 @@ go.work
 
 # executable
 raygo
+
+# Image outputs
+out.jpg
+out.png
+out.ppm

--- a/Makefile
+++ b/Makefile
@@ -3,27 +3,26 @@
 fmt:
 	go fmt ./...
 
-lint: fmt
-	go lint ./...
-
-vet: fmt
+vet:
 	go vet ./...
 
-cover: fmt
+test:
+	go test ./...
+
+check: vet test
+
+cover:
 	go test -v -cover -coverprofile=c.out ./...
 	go tool cover -html=c.out
 
-test: vet
-	go test ./...
-
-t: test
-
-build: vet
+build:
 	go build raygo.go
 
 b: build
 
-run: vet
+run:
 	go run raygo.go
 
 r: run
+
+t: test

--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# Raygo: A Golang CPU-based 3D Ray-tracer
+# Raygo: A Golang CPU-Based 3D Ray Tracer
+
+## Requirements
+- Go `1.21.x` (recommended for local parity with CI)
+
+## Quick Start
+```bash
+make check
+make run
+```
+
+The demo writes:
+- `out.ppm`
+- `out.png`
+- `out.jpg`
+
+## Notes
+- Internal color math uses linear `float32` RGB.
+- Image export currently clamps to display range `[0,1]` and quantizes at output boundaries.

--- a/raygo.go
+++ b/raygo.go
@@ -14,8 +14,12 @@ func main() {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {
 			canvas.SetLinear(x, y, tracer.ColorGrey)
 			r := tracer.NewRay(tracer.NewPoint(float64(x), float64(y), 0), tracer.NewVector(0, 0, -1))
-			if _, ok := tracer.Hit(sphere.GetIntersects(r)); ok {
-				canvas.SetLinear(x, y, tracer.ColorRed)
+			intersects := sphere.GetIntersects(r)
+			for _, time := range tracer.GetIntersectTimes(intersects) {
+				if time > 0 {
+					canvas.SetLinear(x, y, tracer.ColorRed)
+					break
+				}
 			}
 		}
 	}

--- a/raygo.go
+++ b/raygo.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+
 	"github.com/jason-h-35/raygo/tracer"
 )
 
@@ -11,22 +12,25 @@ func main() {
 	bounds := canvas.Bounds()
 	for y := bounds.Min.Y; y < bounds.Max.Y; y++ {
 		for x := bounds.Min.X; x < bounds.Max.X; x++ {
-			canvas.Set(x, y, tracer.ColorGrey)
+			canvas.SetLinear(x, y, tracer.ColorGrey)
 			r := tracer.NewRay(tracer.NewPoint(float64(x), float64(y), 0), tracer.NewVector(0, 0, -1))
-			intersects := sphere.GetIntersects(r)
-			for _, time := range tracer.GetIntersectTimes(intersects) {
-				if time > 0 {
-					canvas.Set(x, y, tracer.ColorRed)
-					break
-				}
+			if _, ok := tracer.Hit(sphere.GetIntersects(r)); ok {
+				canvas.SetLinear(x, y, tracer.ColorRed)
 			}
-			fmt.Println(x, y)
 		}
 	}
-	bytes, err := canvas.PPMFile(255, "/home/jason/out.ppm")
-	canvas.PNGFile("/home/jason/out.png")
+
+	bytes, err := canvas.PPMFile(255, "out.ppm")
 	if err != nil {
-		fmt.Println(err)
+		fmt.Printf("failed to write PPM: %v\n", err)
+	} else {
+		fmt.Printf("wrote %d bytes to out.ppm\n", bytes)
 	}
-	fmt.Println(bytes)
+
+	if err := canvas.PNGFile("out.png"); err != nil {
+		fmt.Printf("failed to write PNG: %v\n", err)
+	}
+	if err := canvas.JPEGFile("out.jpg", 95); err != nil {
+		fmt.Printf("failed to write JPEG: %v\n", err)
+	}
 }

--- a/tracer/bench_test.go
+++ b/tracer/bench_test.go
@@ -15,7 +15,7 @@ type benchResults struct {
 	}
 	// Color results
 	color struct {
-		c     HDRColor
+		c     LinearColor
 		float float64
 	}
 	// Ray results

--- a/tracer/canvas.go
+++ b/tracer/canvas.go
@@ -49,9 +49,6 @@ func (c *Canvas) Bounds() image.Rectangle {
 	if len(c.image) == 0 {
 		return image.Rect(0, 0, 0, 0)
 	}
-	if len(c.image[0]) == 0 {
-		return image.Rect(0, 0, len(c.image), 0)
-	}
 	return image.Rect(0, 0, len(c.image), len(c.image[0]))
 }
 

--- a/tracer/canvas.go
+++ b/tracer/canvas.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"image"
 	"image/color"
+	"image/jpeg"
 	"image/png"
 	"os"
 	"strconv"
@@ -11,36 +12,46 @@ import (
 )
 
 type Canvas struct {
-	image [][]HDRColor
+	image [][]LinearColor
 }
 
 func NewCanvas(xMax, yMax int) Canvas {
-	image := make([][]HDRColor, xMax)
+	image := make([][]LinearColor, xMax)
 	for i := range image {
-		image[i] = make([]HDRColor, yMax)
+		image[i] = make([]LinearColor, yMax)
 	}
 	return Canvas{image}
 }
 
 func (c *Canvas) At(x, y int) color.Color {
-	if !(image.Point{x, y}.In(c.Bounds())) {
-		return HDRColor{}
+	pixel := c.AtLinear(x, y)
+	r, g, b, a := pixel.RGBA()
+	return color.RGBA64{
+		R: uint16(r),
+		G: uint16(g),
+		B: uint16(b),
+		A: uint16(a),
 	}
-	return c.image[x][y]
 }
 
-func (c *Canvas) AtHDR(x, y int) HDRColor {
+func (c *Canvas) AtLinear(x, y int) LinearColor {
 	if !(image.Point{x, y}.In(c.Bounds())) {
-		return HDRColor{}
+		return LinearColor{}
 	}
 	return c.image[x][y]
 }
 
 func (c *Canvas) ColorModel() color.Model {
-	return color.RGBAModel
+	return color.RGBA64Model
 }
 
 func (c *Canvas) Bounds() image.Rectangle {
+	if len(c.image) == 0 {
+		return image.Rect(0, 0, 0, 0)
+	}
+	if len(c.image[0]) == 0 {
+		return image.Rect(0, 0, len(c.image), 0)
+	}
 	return image.Rect(0, 0, len(c.image), len(c.image[0]))
 }
 
@@ -50,11 +61,14 @@ func (c *Canvas) Set(x, y int, clr color.Color) {
 		return
 	}
 	r, g, b, _ := clr.RGBA()
-	// Convert from uint32 [0-65535] to float64 [0-1]
-	c.image[x][y] = HDRColor{uint64(r), uint64(g), uint64(b)}
+	c.image[x][y] = LinearColor{
+		R: float32(r) / 65535,
+		G: float32(g) / 65535,
+		B: float32(b) / 65535,
+	}
 }
 
-func (c *Canvas) SetColor(x, y int, clr HDRColor) {
+func (c *Canvas) SetLinear(x, y int, clr LinearColor) {
 	bounds := c.Bounds().Max
 	if x < 0 || x >= bounds.X || y < 0 || y >= bounds.Y {
 		return
@@ -75,10 +89,9 @@ func (c *Canvas) PPMStr(maxColorVal uint64) string {
 	lineLen := 0
 	for y := 0; y < bounds.Y; y++ {
 		for x := 0; x < bounds.X; x++ {
-			pixel := c.image[x][y].ToPPMRange(maxColorVal)
-			r, g, b := int(pixel.R), int(pixel.G), int(pixel.B)
-			for _, v := range []int{r, g, b} {
-				s := strconv.Itoa(v)
+			r, g, b := c.image[x][y].ToPPMRange(maxColorVal)
+			for _, v := range []uint64{r, g, b} {
+				s := strconv.FormatUint(v, 10)
 				// Add newline if this component would exceed line length
 				if lineLen > 0 && lineLen+len(s) >= maxLineLen {
 					builder.WriteString(lineSep)
@@ -101,13 +114,12 @@ func (c *Canvas) PPMStr(maxColorVal uint64) string {
 
 func (c *Canvas) PPMFile(maxColorVal uint64, writePath string) (int, error) {
 	ppmStr := c.PPMStr(maxColorVal)
-	file, fileErr := os.Create(writePath)
-	defer file.Close()
-	if fileErr != nil {
-		fmt.Println(fileErr)
-		return 0, fileErr
+	file, err := os.Create(writePath)
+	if err != nil {
+		return 0, err
 	}
-	return fmt.Fprintf(file, "%v", ppmStr)
+	defer file.Close()
+	return file.WriteString(ppmStr)
 }
 
 func (c *Canvas) PNGFile(writePath string) error {
@@ -119,6 +131,23 @@ func (c *Canvas) PNGFile(writePath string) error {
 
 	if err := png.Encode(file, c); err != nil {
 		return fmt.Errorf("failed to encode PNG: %w", err)
+	}
+	return nil
+}
+
+func (c *Canvas) JPEGFile(writePath string, quality int) error {
+	file, err := os.Create(writePath)
+	if err != nil {
+		return fmt.Errorf("failed to create JPEG file: %w", err)
+	}
+	defer file.Close()
+
+	if quality < 1 || quality > 100 {
+		quality = 95
+	}
+
+	if err := jpeg.Encode(file, c, &jpeg.Options{Quality: quality}); err != nil {
+		return fmt.Errorf("failed to encode JPEG: %w", err)
 	}
 	return nil
 }

--- a/tracer/canvas_bench_test.go
+++ b/tracer/canvas_bench_test.go
@@ -27,24 +27,24 @@ func BenchmarkCanvasCreation(b *testing.B) {
 
 func BenchmarkCanvasOperations(b *testing.B) {
 	canvas := NewCanvas(100, 100)
-	clr := HDRColor{0x8000, 0x4000, 0x2000}
+	clr := LinearColor{0.8, 0.4, 0.2}
 	rgbaClr := color.RGBA{128, 64, 32, 255}
 
 	b.Run("At/InBounds", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			results.color.c = canvas.AtHDR(50, 50)
+			results.color.c = canvas.AtLinear(50, 50)
 		}
 	})
 
 	b.Run("At/OutOfBounds", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			results.color.c = canvas.AtHDR(150, 150)
+			results.color.c = canvas.AtLinear(150, 150)
 		}
 	})
 
-	b.Run("Set/HDRColor", func(b *testing.B) {
+	b.Run("Set/LinearColor", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
-			canvas.SetColor(50, 50, clr)
+			canvas.SetLinear(50, 50, clr)
 		}
 	})
 
@@ -57,13 +57,12 @@ func BenchmarkCanvasOperations(b *testing.B) {
 
 func BenchmarkCanvasExport(b *testing.B) {
 	canvas := NewCanvas(100, 100)
-	// Fill canvas with some test data
 	for x := 0; x < 100; x++ {
 		for y := 0; y < 100; y++ {
-			canvas.SetColor(x, y, HDRColor{
-				R: uint64(x * 256),
-				G: uint64(y * 256),
-				B: uint64((x + y) * 128),
+			canvas.SetLinear(x, y, LinearColor{
+				R: float32(x) / 99,
+				G: float32(y) / 99,
+				B: float32(x+y) / 198,
 			})
 		}
 	}

--- a/tracer/color_bench_test.go
+++ b/tracer/color_bench_test.go
@@ -1,8 +1,6 @@
 package tracer
 
-import (
-	"testing"
-)
+import "testing"
 
 func BenchmarkColorCreation(b *testing.B) {
 	b.Run("NewColorFromFloat64", func(b *testing.B) {
@@ -13,9 +11,9 @@ func BenchmarkColorCreation(b *testing.B) {
 }
 
 func BenchmarkColorOperations(b *testing.B) {
-	c1 := HDRColor{0x8000, 0x4000, 0x2000}
-	c2 := HDRColor{0x2000, 0x4000, 0x8000}
-	f := uint64(2)
+	c1 := LinearColor{0.8, 0.4, 0.2}
+	c2 := LinearColor{0.2, 0.4, 0.8}
+	f := float32(2)
 
 	b.Run("Plus", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -43,43 +41,44 @@ func BenchmarkColorOperations(b *testing.B) {
 }
 
 func BenchmarkColorConversions(b *testing.B) {
-	c := HDRColor{0x8000, 0x4000, 0x2000}
+	c := LinearColor{0.8, 0.4, 0.2}
 
 	b.Run("RGBA", func(be *testing.B) {
 		var r, g, b uint32
 		for i := 0; i < be.N; i++ {
 			r, g, b, _ = c.RGBA()
-			// Store in results to prevent optimization
-			results.color.c = HDRColor{uint64(r), uint64(g), uint64(b)}
+			results.scalar.float = float64(r + g + b)
 		}
 	})
 
 	b.Run("ToPPMRange", func(b *testing.B) {
+		var r, g, bl uint64
 		for i := 0; i < b.N; i++ {
-			results.color.c = c.ToPPMRange(255)
+			r, g, bl = c.ToPPMRange(255)
+			results.scalar.float = float64(r + g + bl)
 		}
 	})
 
 	b.Run("AsFloats", func(be *testing.B) {
-		var r, g, b float64
+		var r, g, bl float32
 		for i := 0; i < be.N; i++ {
-			r, g, b = c.AsFloats()
-			results.scalar.float = r + g + b // Store to prevent optimization
+			r, g, bl = c.AsFloats()
+			results.scalar.float = float64(r + g + bl)
 		}
 	})
 
 	b.Run("AsInts", func(be *testing.B) {
-		var r, g, b int
+		var r, g, bl int
 		for i := 0; i < be.N; i++ {
-			r, g, b = c.AsInts()
-			results.scalar.float = float64(r + g + b) // Store to prevent optimization
+			r, g, bl = c.AsInts()
+			results.scalar.float = float64(r + g + bl)
 		}
 	})
 }
 
 func BenchmarkColorComparisons(b *testing.B) {
-	c1 := HDRColor{0x8000, 0x4000, 0x2000}
-	c2 := HDRColor{0x2000, 0x4000, 0x8000}
+	c1 := LinearColor{0.8, 0.4, 0.2}
+	c2 := LinearColor{0.2, 0.4, 0.8}
 
 	b.Run("Equals", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {
@@ -88,10 +87,10 @@ func BenchmarkColorComparisons(b *testing.B) {
 	})
 
 	b.Run("Distance", func(b *testing.B) {
-		var d uint64
+		var d float32
 		for i := 0; i < b.N; i++ {
 			d = c1.Distance(c2)
-			results.color.c.R = d // Store to prevent optimization
+			results.scalar.float = float64(d)
 		}
 	})
 }

--- a/tracer/intersect.go
+++ b/tracer/intersect.go
@@ -1,6 +1,7 @@
 package tracer
 
 import (
+	"fmt"
 	"math"
 	"math/rand"
 	"slices"
@@ -75,7 +76,11 @@ func NewSphere(transform Mat[Size4]) Sphere {
 // For a sphere centered at the origin with radius 1, uses the quadratic formula:
 // t^2(d⋅d) + 2t(d⋅(o-c)) + (o-c)⋅(o-c) - r^2 = 0
 func (s Sphere) GetIntersects(r2 Ray) []Intersect {
-	r := r2.Transform(s.transform.Inverse())
+	inv, err := s.transform.Inverse()
+	if err != nil {
+		panic(fmt.Sprintf("Sphere.GetIntersects requires invertible transform: %v", err))
+	}
+	r := r2.Transform(inv)
 	sphereToRay := r.origin.Minus(NewPoint(0, 0, 0))
 	a := r.velocity.Dot(r.velocity)
 	b := 2 * r.velocity.Dot(sphereToRay)

--- a/tracer/intersect.go
+++ b/tracer/intersect.go
@@ -95,7 +95,7 @@ func (s Sphere) GetIntersects(r2 Ray) []Intersect {
 }
 
 func GetIntersectTimes(intersects []Intersect) []float64 {
-	times := make([]float64, len(intersects), len(intersects))
+	times := make([]float64, len(intersects))
 	for i := 0; i < len(intersects); i++ {
 		times[i] = intersects[i].time
 	}
@@ -140,9 +140,10 @@ func Hit(xs []Intersect) (Intersect, bool) {
 	if len(xs) == 0 {
 		return NewIntersect(NewSphere(I4), 0), false
 	}
-	// TODO: Eventually it won't be viable to sort for every Hit calculation
 	if !slices.IsSortedFunc(xs, compareIntersectTime) {
-		slices.SortFunc(xs, compareIntersectTime)
+		sorted := append([]Intersect(nil), xs...)
+		slices.SortFunc(sorted, compareIntersectTime)
+		xs = sorted
 	}
 	for _, x := range xs {
 		if x.time >= 0 {

--- a/tracer/intersect_test.go
+++ b/tracer/intersect_test.go
@@ -201,3 +201,17 @@ func TestRayTransform(t *testing.T) {
 		}
 	}
 }
+
+func TestHitDoesNotMutateInputOrder(t *testing.T) {
+	s := NewSphere(I4)
+	xs := NewIntersects(s, 2, -1, 1)
+	before := append([]Intersect(nil), xs...)
+
+	_, _ = Hit(xs)
+
+	for i := range xs {
+		if !xs[i].Equals(before[i]) {
+			t.Fatalf("Hit mutated input slice at index %d: before=%v after=%v", i, before[i], xs[i])
+		}
+	}
+}

--- a/tracer/matrix.go
+++ b/tracer/matrix.go
@@ -192,19 +192,32 @@ func (a Mat[T]) Determinant() float64 {
 }
 
 func (a Mat[T]) CanInverse() bool {
-	return math.Abs(a.Determinant()) > epsilon
+	return canInverseDeterminant(a.Determinant())
 }
 
 func (a Mat[T]) Inverse() Mat[T] {
-	if !a.CanInverse() {
+	det := a.Determinant()
+	if !canInverseDeterminant(det) {
 		panic("can't inverse this matrix")
 	}
 	size := a.size
+
+	if size == 2 {
+		return NewMat[T]([]float64{
+			a.vals[1][1] / det, -a.vals[0][1] / det,
+			-a.vals[1][0] / det, a.vals[0][0] / det,
+		})
+	}
+
 	inverse := NewMat[T](make([]float64, size*size))
 	for i, row := range a.vals {
 		for j := range row {
-			inverse.vals[j][i] = Cofactor(a, i, j) / a.Determinant()
+			inverse.vals[j][i] = Cofactor(a, i, j) / det
 		}
 	}
 	return inverse
+}
+
+func canInverseDeterminant(det float64) bool {
+	return math.Abs(det) > epsilon
 }

--- a/tracer/matrix_bench_test.go
+++ b/tracer/matrix_bench_test.go
@@ -113,20 +113,32 @@ func BenchmarkMatrixInverse(b *testing.B) {
 	})
 
 	b.Run("Inverse/2x2", func(b *testing.B) {
+		var err error
 		for i := 0; i < b.N; i++ {
-			results.matrix.mat2 = m2.Inverse()
+			results.matrix.mat2, err = m2.Inverse()
+			if err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 
 	b.Run("Inverse/3x3", func(b *testing.B) {
+		var err error
 		for i := 0; i < b.N; i++ {
-			results.matrix.mat3 = m3.Inverse()
+			results.matrix.mat3, err = m3.Inverse()
+			if err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 
 	b.Run("Inverse/4x4", func(b *testing.B) {
+		var err error
 		for i := 0; i < b.N; i++ {
-			results.matrix.mat4 = m4.Inverse()
+			results.matrix.mat4, err = m4.Inverse()
+			if err != nil {
+				b.Fatal(err)
+			}
 		}
 	})
 }

--- a/tracer/matrix_bench_test.go
+++ b/tracer/matrix_bench_test.go
@@ -112,12 +112,11 @@ func BenchmarkMatrixInverse(b *testing.B) {
 		}
 	})
 
-	// BUG: Minor only supported for Mat3 and Mat4
-	// b.Run("Inverse/2x2", func(b *testing.B) {
-	// 	for i := 0; i < b.N; i++ {
-	// 		results.matrix.mat2 = m2.Inverse()
-	// 	}
-	// })
+	b.Run("Inverse/2x2", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			results.matrix.mat2 = m2.Inverse()
+		}
+	})
 
 	b.Run("Inverse/3x3", func(b *testing.B) {
 		for i := 0; i < b.N; i++ {

--- a/tracer/matrix_test.go
+++ b/tracer/matrix_test.go
@@ -247,3 +247,12 @@ func Test_Mat4InverseIdent(t *testing.T) {
 		t.Errorf("A * B * B' should be A but instead was %v", result)
 	}
 }
+
+func Test_Mat2Inverse(t *testing.T) {
+	a := NewMat[Size2]([]float64{4, 7, 2, 6})
+	expect := NewMat[Size2]([]float64{0.6, -0.7, -0.2, 0.4})
+	result := a.Inverse()
+	if !result.Equals(expect) {
+		t.Errorf("%v Inverse should be %v but was %v", a, expect, result)
+	}
+}

--- a/tracer/matrix_test.go
+++ b/tracer/matrix_test.go
@@ -230,7 +230,10 @@ func Test_Mat4Inverse(t *testing.T) {
 		NewMat[Size4]([]float64{-0.04074, -0.07778, 0.14444, -0.22222, -0.07778, 0.03333, 0.36667, -0.33333, -0.02901, -0.14630, -0.10926, 0.12963, 0.17778, 0.06667, -0.26667, 0.33333}),
 	}
 	for i := range mats {
-		result := mats[i].Inverse()
+		result, err := mats[i].Inverse()
+		if err != nil {
+			t.Fatalf("Inverse() failed for %v: %v", mats[i], err)
+		}
 		if !result.Equals(inverses[i]) {
 			t.Errorf("%v Inverse should be %v but was %v", mats[i], inverses[i], result)
 		}
@@ -241,7 +244,10 @@ func Test_Mat4InverseIdent(t *testing.T) {
 	a := NewMat[Size4]([]float64{3, -9, 7, 3, 3, -8, 2, -9, -4, 4, 4, 1, -6, 5, -1, 1})
 	b := NewMat[Size4]([]float64{8, 2, 2, 2, 3, -1, 7, 0, 7, 0, 5, 4, 6, -2, 0, 5})
 	c := a.Times(b)
-	bI := b.Inverse()
+	bI, err := b.Inverse()
+	if err != nil {
+		t.Fatalf("Inverse() failed for %v: %v", b, err)
+	}
 	result := c.Times(bI)
 	if !result.Equals(a) {
 		t.Errorf("A * B * B' should be A but instead was %v", result)
@@ -251,8 +257,18 @@ func Test_Mat4InverseIdent(t *testing.T) {
 func Test_Mat2Inverse(t *testing.T) {
 	a := NewMat[Size2]([]float64{4, 7, 2, 6})
 	expect := NewMat[Size2]([]float64{0.6, -0.7, -0.2, 0.4})
-	result := a.Inverse()
+	result, err := a.Inverse()
+	if err != nil {
+		t.Fatalf("Inverse() failed for %v: %v", a, err)
+	}
 	if !result.Equals(expect) {
 		t.Errorf("%v Inverse should be %v but was %v", a, expect, result)
+	}
+}
+
+func Test_InverseReturnsErrorForSingularMatrix(t *testing.T) {
+	a := NewMat[Size4]([]float64{-4, 2, -2, -3, 9, 6, 2, 6, 0, -5, 1, -5, 0, 0, 0, 0})
+	if _, err := a.Inverse(); err == nil {
+		t.Fatalf("expected Inverse() to return error for singular matrix")
 	}
 }

--- a/tracer/transform_test.go
+++ b/tracer/transform_test.go
@@ -5,6 +5,15 @@ import (
 	"testing"
 )
 
+func mustInverse[T ~int](t *testing.T, m Mat[T]) Mat[T] {
+	t.Helper()
+	inv, err := m.Inverse()
+	if err != nil {
+		t.Fatalf("Inverse() failed: %v", err)
+	}
+	return inv
+}
+
 func TestTransform(t *testing.T) {
 	tests := []struct {
 		name      string
@@ -20,7 +29,7 @@ func TestTransform(t *testing.T) {
 		},
 		{
 			name:      "Inverse translation moves a point in the opposite direction",
-			transform: I4.Translate(5, -3, 2).Inverse(),
+			transform: mustInverse(t, I4.Translate(5, -3, 2)),
 			pt:        NewPoint(-3, 4, 5),
 			expect:    NewPoint(-8, 7, 3),
 		},
@@ -44,7 +53,7 @@ func TestTransform(t *testing.T) {
 		},
 		{
 			name:      "Inverse of scaling matrix",
-			transform: I4.Scale(2, 3, 4).Inverse(),
+			transform: mustInverse(t, I4.Scale(2, 3, 4)),
 			pt:        NewVector(-4, 6, 8),
 			expect:    NewVector(-2, 2, 2),
 		},
@@ -68,7 +77,7 @@ func TestTransform(t *testing.T) {
 		},
 		{
 			name:      "Inverse of X rotation rotates in opposite direction",
-			transform: I4.RotateX(math.Pi / 4.).Inverse(),
+			transform: mustInverse(t, I4.RotateX(math.Pi/4.)),
 			pt:        NewPoint(0, 1, 0),
 			expect:    NewPoint(0, math.Sqrt(2)/2., -math.Sqrt(2)/2.),
 		},


### PR DESCRIPTION
HDRColor used int64 which made for annoying arithmetic and long runtimes without any noticeable benefit to color output.

Inverse() was initially written to panic when the matrix has no inverse but now will use err instead of panicking.